### PR TITLE
Support legacy web order products contract in mobile app

### DIFF
--- a/docs/SHARED_ORDER_CONTRACT.md
+++ b/docs/SHARED_ORDER_CONTRACT.md
@@ -1,0 +1,164 @@
+# Shared Order Contract
+
+## Purpose
+
+This document defines the shared order contract used by the React Native app, the web app, and the current Supabase schema.
+
+The goal is to keep both clients compatible without breaking:
+- `orders.products`
+- kitchen printing
+- cashier/payment flows
+- historical orders already stored in production
+
+## Current production source of truth
+
+Today, the production-safe contract is the one already used by the web app and stored in Supabase:
+
+- `orders.products` is a JSON array
+- each entry in `orders.products` represents one order line
+- the mobile app must write that same array shape
+- both apps may read older or richer payloads defensively, but must not write a different shape to production without a coordinated migration
+
+## Shared order payload
+
+`orders.products` must be an array:
+
+```json
+[
+  {
+    "id": 163,
+    "name": "Lomo Saltado",
+    "nameEs": "Lomo Saltado",
+    "nameEn": "Lomo Saltado",
+    "nameJa": "ロモ・サルタード",
+    "quantity": 1,
+    "price": 3200,
+    "notes": "sin cebolla",
+    "selectedOptions": ["Spice: Mild"]
+  }
+]
+```
+
+## Required line fields
+
+Every order line should include:
+
+- `id`
+- `name`
+- `quantity`
+- `price`
+
+## Optional line fields
+
+These are allowed and should be tolerated by both apps even if not fully rendered everywhere:
+
+- `nameEs`
+- `nameEn`
+- `nameJa`
+- `notes`
+- `selectedOptions`
+- `image`
+- `category`
+- `macroCategory`
+- `prepTime`
+
+## Fields that are not part of `orders.products`
+
+These must not be treated as part of the shared persisted order-line contract:
+
+- `customerName`
+- `orderType`
+- `draft`
+
+Current rule:
+
+- mobile may use these locally for the active checkout flow
+- web must not be forced to read them from `orders.products`
+- if these values need to be persisted for both apps, they should move to dedicated database fields or a separate versioned metadata field
+
+`tableNumber` is UI-facing data and should be resolved from `table_id` and the related table record when possible.
+
+## Currency rule
+
+All prices must use the same convention across:
+
+- `dishes.price`
+- `orders.total`
+- app UI totals
+- cashier/kitchen calculations
+
+Rule:
+
+- use yen integer amounts
+- do not mix scales like `8`, `800`, and `8.00` to represent different meanings
+
+Examples:
+
+- `800`
+- `1600`
+- `3200`
+
+## Status rule
+
+The apps should normalize to the same operational statuses:
+
+- `pending`
+- `preparing`
+- `ready`
+- `delivered`
+
+If a client receives a different database value, it should map it explicitly instead of guessing.
+
+## Image rule
+
+Both apps should follow the same image resolution order:
+
+1. use `image` when it is already a public URL
+2. otherwise build a public URL from `image_path`
+3. otherwise render a stable `No Image` placeholder
+
+## Compatibility rules
+
+Until a coordinated migration exists:
+
+- web writes `orders.products` as an array
+- mobile writes `orders.products` as an array
+- web should continue reading the array format
+- mobile may read both:
+  - legacy array format
+  - richer object-shaped formats from older experiments or fallback paths
+
+Important:
+
+- do not change the production write contract for `orders.products` in one app only
+- do not introduce `{ draft, items }` as the production write shape
+
+## Client responsibilities
+
+### Web app
+
+- validates `products` as a non-empty array on order creation
+- treats `products` as the persisted shared contract
+- should tolerate optional `notes` and `selectedOptions`
+
+### Mobile app
+
+- may keep richer UI state locally for cart/configurator/history
+- must serialize new orders back to the shared array contract before insert
+- must not assume `customerName` or `orderType` can be recovered from production history unless they are persisted elsewhere
+
+## Future migration rule
+
+If the team wants a richer shared contract later, do not replace `orders.products` in place without coordination.
+
+Do this instead:
+
+1. define the target versioned contract
+2. update web and mobile readers first
+3. update writers in a controlled rollout
+4. migrate historical data only if needed
+5. remove legacy compatibility only after both apps are aligned
+
+Related issue:
+
+- `peruchos-app#1` Define future unified contract for `orders.products`

--- a/src/screens/MenuScreen.tsx
+++ b/src/screens/MenuScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Pressable, Text, TextInput, View } from "react-native";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -197,7 +197,11 @@ export function MenuScreen() {
               </View>
             </View>
 
-            <View className="flex-1 gap-3 py-4">
+            <ScrollView
+              className="flex-1 py-4"
+              contentContainerClassName="gap-3"
+              showsVerticalScrollIndicator={false}
+            >
               {cartItems.length === 0 ? (
                 <View className="rounded-[22px] bg-[#faf6f4] p-4">
                   <Text className="text-[16px] text-[#232120]" style={{ fontFamily: "Inter_800ExtraBold" }}>
@@ -210,7 +214,7 @@ export function MenuScreen() {
               ) : (
                 cartItems.map((item) => <CartItem key={item.lineId} item={item} />)
               )}
-            </View>
+            </ScrollView>
 
             <View className="gap-3 border-t border-[#efebe8] pt-4">
               <View className="gap-2 rounded-[20px] bg-[#faf6f4] px-4 py-4">

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -370,5 +370,10 @@ describe("api service behavior", () => {
       selectedOptions: ["Spice: Mild"],
       title: "Lomo Saltado",
     });
+    expect(created.draft).toEqual({
+      customerName: "Cesar",
+      orderType: "Dine In",
+      tableNumber: "12",
+    });
   });
 });

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -49,7 +49,7 @@ describe("api service behavior", () => {
     expect(payload.items.length).toBeGreaterThan(0);
   });
 
-  it("maps fetched orders and normalizes legacy items missing selectedOptions", async () => {
+  it("maps fetched orders from legacy array products and normalizes missing selectedOptions", async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table !== "orders") {
         throw new Error(`Unexpected table ${table}`);
@@ -63,24 +63,16 @@ describe("api service behavior", () => {
                 created_at: "2026-03-30T12:00:00.000Z",
                 id: 77,
                 kitchen_status: "ready",
-                products: {
-                  draft: {
-                    customerName: "Cesar",
-                    orderType: "Dine In",
-                    tableNumber: "",
+                products: [
+                  {
+                    category: "Bebida",
+                    id: "dish-1",
+                    name: "Inca Kola",
+                    notes: "",
+                    price: 1600,
+                    quantity: 2,
                   },
-                  items: [
-                    {
-                      category: "Bebida",
-                      description: "Gaseosa",
-                      id: "dish-1",
-                      note: "",
-                      price: 1600,
-                      quantity: 2,
-                      title: "Inca Kola",
-                    },
-                  ],
-                },
+                ],
                 table_id: 12,
                 tables: { id: 12, table_number: 12 },
                 total: 3200,
@@ -105,6 +97,7 @@ describe("api service behavior", () => {
       },
     });
     expect(orders[0].draft.tableNumber).toBe("12");
+    expect(orders[0].draft.customerName).toBe("");
     expect(orders[0].items[0].selectedOptions).toEqual([]);
     expect(orders[0].items[0].lineId).toBe("dish-1-0");
   });
@@ -277,5 +270,105 @@ describe("api service behavior", () => {
     expect(created.summary).toEqual(input.summary);
     expect(created.draft).toEqual(input.draft);
     expect(created.items).toEqual(input.items);
+  });
+
+  it("writes products as a legacy-compatible array when creating an order", async () => {
+    const insertSingle = jest.fn().mockResolvedValue({
+      data: {
+        id: 200,
+        created_at: "2026-03-30T10:00:00.000Z",
+        total: 3200,
+        products: [
+          {
+            id: 163,
+            name: "Lomo Saltado",
+            notes: "sin cebolla",
+            price: 3200,
+            quantity: 1,
+            selectedOptions: ["Spice: Mild"],
+          },
+        ],
+        kitchen_status: "pending",
+        table_id: 12,
+        tables: { id: 12, table_number: 12 },
+      },
+      error: null,
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "tables") {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 12, table_number: 12 },
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "orders") {
+        return {
+          insert: jest.fn((payload: Record<string, unknown>) => {
+            expect(payload.products).toEqual([
+              expect.objectContaining({
+                id: 163,
+                name: "Lomo Saltado",
+                notes: "sin cebolla",
+                price: 3200,
+                quantity: 1,
+                selectedOptions: ["Spice: Mild"],
+              }),
+            ]);
+
+            return {
+              select: jest.fn(() => ({
+                single: insertSingle,
+              })),
+            };
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const { createOrder } = loadApi();
+    const created = await createOrder({
+      draft: {
+        customerName: "Cesar",
+        orderType: "Dine In",
+        tableNumber: "12",
+      },
+      items: [
+        {
+          category: "Platos Principales",
+          description: "Salteado criollo",
+          id: "163",
+          lineId: "163-a",
+          macroCategory: "food",
+          note: "sin cebolla",
+          prepTime: "25 min",
+          price: 3200,
+          quantity: 1,
+          selectedOptions: ["Spice: Mild"],
+          title: "Lomo Saltado",
+        },
+      ],
+      summary: {
+        itemCount: 1,
+        subtotal: 3200,
+      },
+    });
+
+    expect(created.id).toBe("200");
+    expect(created.items[0]).toMatchObject({
+      id: "163",
+      note: "sin cebolla",
+      quantity: 1,
+      selectedOptions: ["Spice: Mild"],
+      title: "Lomo Saltado",
+    });
   });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -473,8 +473,11 @@ export async function createOrder(input: {
       },
       draft: {
         ...parsed.draft,
+        ...input.draft,
         tableNumber:
-          parsed.draft.tableNumber || (linkedTable?.table_number ? String(linkedTable.table_number) : ""),
+          parsed.draft.tableNumber ||
+          input.draft.tableNumber ||
+          (linkedTable?.table_number ? String(linkedTable.table_number) : ""),
       },
       status: normalizeOrderStatus(data.kitchen_status),
     };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -52,6 +52,26 @@ type OrderRow = {
   tables?: TableRow | TableRow[] | null;
 };
 
+type LegacyOrderProduct = {
+  id?: number | string;
+  image?: string | null;
+  image_path?: string | null;
+  macroCategory?: string;
+  category?: string;
+  name?: string;
+  nameEs?: string;
+  nameEn?: string;
+  nameJa?: string;
+  title?: string;
+  description?: string;
+  prepTime?: string;
+  price?: number | string;
+  quantity?: number;
+  note?: string;
+  notes?: string;
+  selectedOptions?: string[];
+};
+
 const NETWORK_DELAY_MS = 120;
 
 function wait(duration = NETWORK_DELAY_MS) {
@@ -107,6 +127,13 @@ function parseOrderProducts(value: unknown): {
     return { draft: fallbackDraft, items: [] };
   }
 
+  if (Array.isArray(value)) {
+    return {
+      draft: fallbackDraft,
+      items: value.map((item, index) => normalizeLegacyOrderProduct(item as LegacyOrderProduct, index)),
+    };
+  }
+
   const products = value as {
     draft?: Partial<CheckoutDraft>;
     items?: CartEntry[];
@@ -120,6 +147,44 @@ function parseOrderProducts(value: unknown): {
     items: Array.isArray(products.items)
       ? products.items.map((item, index) => normalizeCartEntry(item, index))
       : [],
+  };
+}
+
+function normalizeLegacyOrderProduct(item: LegacyOrderProduct, index = 0): CartEntry {
+  const title =
+    item.title ??
+    item.name ??
+    item.nameEs ??
+    item.nameEn ??
+    item.nameJa ??
+    "";
+  const baseId = item.id != null ? String(item.id) : `legacy-${index}`;
+  const numericPrice =
+    typeof item.price === "number"
+      ? item.price
+      : typeof item.price === "string"
+        ? Number(item.price)
+        : 0;
+  const image =
+    typeof item.image === "string" && item.image.length > 0
+      ? item.image
+      : typeof item.image_path === "string" && item.image_path.length > 0
+        ? supabase.storage.from("dishes").getPublicUrl(item.image_path).data.publicUrl
+        : undefined;
+
+  return {
+    category: item.category ?? "",
+    description: item.description ?? "",
+    id: baseId,
+    image,
+    lineId: `${baseId}-${index}`,
+    macroCategory: item.macroCategory ?? "food",
+    note: typeof item.note === "string" ? item.note : typeof item.notes === "string" ? item.notes : "",
+    prepTime: item.prepTime ?? "15 min",
+    price: Number.isFinite(numericPrice) ? numericPrice : 0,
+    quantity: typeof item.quantity === "number" && item.quantity > 0 ? item.quantity : 1,
+    selectedOptions: Array.isArray(item.selectedOptions) ? item.selectedOptions : [],
+    title,
   };
 }
 
@@ -151,6 +216,22 @@ function normalizeSubmittedOrder(order: SubmittedOrder): SubmittedOrder {
     summary: { ...order.summary },
     draft: { ...order.draft },
   };
+}
+
+function serializeOrderProducts(items: SubmittedOrder["items"]): LegacyOrderProduct[] {
+  return items.map((item) => ({
+    id: /^\d+$/u.test(item.id) ? Number(item.id) : item.id,
+    image: item.image,
+    category: item.category,
+    macroCategory: item.macroCategory,
+    name: item.title,
+    notes: item.note || undefined,
+    prepTime: item.prepTime,
+    price: item.price,
+    quantity: item.quantity,
+    selectedOptions: item.selectedOptions,
+    title: item.title,
+  }));
 }
 
 function formatPrepTime(minutes: number | null) {
@@ -365,10 +446,7 @@ export async function createOrder(input: {
     time: now.toTimeString().slice(0, 5),
     total,
     table_id: tableId,
-    products: {
-      draft: input.draft,
-      items: input.items.map((item) => normalizeCartEntry(item)),
-    },
+    products: serializeOrderProducts(input.items),
   };
 
   try {


### PR DESCRIPTION
## Summary

This PR adapts the React Native app to the current `orders.products` contract already used by the web app and stored in Supabase.

## Why

The web app currently:
- validates `products` as a JSON array
- writes `orders.products` as an array
- reads `orders.products` as an array in ordering, kitchen, cashier, tracking, and receipt flows

The mobile app had started assuming a newer object shape for `orders.products`, which would create incompatibility with the existing web app and historical orders.

## What changed

- mobile order reads now support both:
  - legacy array format
  - object format with `draft` + `items`
- mobile order writes now use the legacy array format so new mobile orders remain compatible with the web app
- newly created mobile orders preserve local draft metadata for immediate UX after submit
- added a shared order contract document in `docs/SHARED_ORDER_CONTRACT.md`
- fixed tablet cart scrolling so order lines remain visible in the right panel
- tests were updated to cover:
  - reading legacy orders
  - writing legacy-compatible payloads
  - preserving mobile draft metadata after create

## Scope

This PR does not:
- change the database schema
- migrate historical orders
- change the web app contract

## Result

- no breakage for the web app
- no breakage for historical orders
- mobile stays compatible with current production data
- tablet self-order flow keeps the cart visible as it grows

## Validation

```bash
npx tsc --noEmit
npm test -- --runInBand
```

## Risk and rollout

Risk is low because this change is compatibility-oriented:
- it expands read support
- it aligns write behavior with the current production contract
- it avoids a breaking contract change in `orders.products`

Recommended rollout:
1. verify one mobile-created order in Supabase
2. verify the same order is readable from the web app
3. verify kitchen/history/cashier flows still display the order correctly
4. verify tablet cart scrolling with multiple items
5. merge only after that cross-check passes

Closes #1
